### PR TITLE
Benzalk attacks without jumping

### DIFF
--- a/src/nodes/projectiles/benzalkFire.lua
+++ b/src/nodes/projectiles/benzalkFire.lua
@@ -13,7 +13,7 @@ return{
   enemyCanPickUp = false,
   canPlayerStore = true,
   velocity = { x = 0, y = 0 }, --initial velocity
-  throwVelocityX = 400,
+  throwVelocityX = 300,
   throwVelocityY = 0,
   thrown = false,
   damage = 10,


### PR DESCRIPTION
- Benzalk now attacks without jumping. This happens more frequently closer to his death.
- Benzalk will return to his guard position and then wait patiently for the player to return to the bridge.
- Benzalk no longer gets too close to the player that the fire projectiles don't register hits.

Also did some cleanup and found a few more lines of dead code.