### PR TITLE
Don't attack multiple enemies with water spout

### DIFF
--- a/src/nodes/projectiles/waterSpout.lua
+++ b/src/nodes/projectiles/waterSpout.lua
@@ -119,7 +119,6 @@ return{
         end)
         Timer.add(0.5, function()
           node:hurt(projectile.damage, projectile.special_damage, 0)
-          projectile.props.hurting = false
         end)
       else
         node:hurt(projectile.damage, projectile.special_damage, 0)


### PR DESCRIPTION
Attacking Turkey's that multiply can cause multiple water spouts to spawn. This resolves this bug.

Once this is merged, we can merge in The Epic!