### PR TITLE
Add end-to-end scenario tests for the #2584 ceiling-collision fix

### DIFF
--- a/HAWKTHORNE_HANDOFF_v2.md
+++ b/HAWKTHORNE_HANDOFF_v2.md
@@ -127,7 +127,7 @@ touching. Only "revive" branches enter the per-feature-PR loop.
 - **Test:** `src/test/test_shopping.lua` (3 cases) — ATTACK exits, START still exits, nav keys
   don't. Stubs `Gamestate.switch`/`sound.playSfx` via the shared cached module tables.
 
-### #2427 / #2578 — collision family: RE-TESTED ✅
+### Collision family — #2456/#2578 VERIFIED ✅ · #2427 OPEN/UNFIXED ⚠️
 - ✅ **Merged PR #2584 ("Addresses two common collision issues", Jun 2022, closes #2456/#2578)
   is present and intact in the current tree** (`ff9fe9c`): the `move_y` downward guard
   (`slope_y >= new_y`), `Player:canStand`/`attack(map)`, and the `level.lua` map plumbing are
@@ -137,11 +137,37 @@ touching. Only "revive" branches enter the per-feature-PR loop.
   test_collision_ceiling.lua` (3 tests) pinning the underlying `collision.move_y` /
   `collision.stand` behaviour. **Proven genuine:** reverting the `slope_y >= new_y` guard makes
   the key test fail with the exact bug symptom (player warps y=30 → y=12); with the guard it passes.
-- **Still to do (needs interactive play, not yet done):** live-repro #2578 (get hit by a bat in
-  the Forest, confirm no ceiling clip) and #2427 (crouch + spam attack/interact on a moving
-  platform in `black-caverns-2`). Maps now compile, so these are loadable — but driving the
-  input interactively is the hard part. Strong evidence both are already fixed; **recommend
-  live-verify then close #2427 (and re-confirm #2578) as resolved.**
+- ✅ **#2578 / #2456 — now VERIFIED end-to-end (PR #48, `ceiling-collision-scenario-tests`).**
+  Added `src/test/test_collision_ceiling_scenario.lua` (3 tests) that drive the **real** Level +
+  Player update loop through the scenario harness: the actual bat knockback impulse
+  (`player.velocity.y = -450`) into a low ceiling stops cleanly at the underside and never clips;
+  the "ceiling edge + gravity down-tick" warp is pinned (reverting the `slope_y >= new_y` guard
+  fails it — player warps box-top 246 → 199, i.e. clips up onto the ceiling); and `Player:canStand`
+  refuses to stand up into a low ceiling. This is the gameplay-level companion the #2584 author
+  said he couldn't write. Suite: **98 passed** (was 95).
+- ⚠️ **#2427 — CORRECTION: this is OPEN and UNFIXED, not "already fixed."** The v2 claim above
+  ("strong evidence both are fixed, close as resolved") was **wrong for #2427**: PR #2584 closed
+  #2456/#2578, NOT #2427. The #2427 thread (issue, not PR) is open with no closing commit and no
+  maintainer verdict. It is a real, timing/geometry-dependent bug: "falling through moving
+  platforms when crouching and spamming attack/interact," and the reporter noted "changing the
+  movement line slightly can resolve it." **Do NOT close it.**
+  - **Reproduction attempt (parked, PR #48 session):** the scenario harness *can* drive
+    moving-platform levels once you run the `node:enter()` hooks that `Level:restartLevel()` skips
+    (they build each platform's Bspline — `movingplatform.lua:110`; without them `update` crashes
+    at `:194 attempt to index field 'bspline'`). Vertical platforms are the candidates
+    (frozencave mp2/mp3, black-caverns mp1/mp6; horizontal ones like black-caverns-2's never
+    stress the fall-through). Riding a vertical platform **downward** with crouch + attack/interact
+    spam for 240 frames did NOT reproduce (player stayed glued, feet-gap 0). Two harness gaps block
+    a faithful repro and must be solved first: (1) **reliable platform attachment** — the player
+    only rides while `player.currentplatform == platform`, which is set by HardonCollider firing
+    `MovingPlatform:collide` on bb overlap; spawning the player *on* a platform doesn't reliably
+    trigger it, so upward-motion trials were invalid. (2) **state leak** — `map.moving_platforms`
+    accumulates across scenarios in one test process (black-caverns-2 reported 5 platforms after
+    black-caverns ran); a clean harness extension needs teardown for this or it causes the exact
+    order-dependent flakiness this doc warns about elsewhere.
+  - **Next step for #2427:** a dedicated harness task (land-player-on-platform helper + moving-
+    platform teardown), then sweep the vertical platforms for the crouch+spam fall-through, then
+    fix. It is NOT a quick verify.
 
 ### Scenario harness — headless gameplay verification ✅ BUILT, tested, deterministic
 This is the big one for AI-driven work: **agents can now assert on real gameplay** (physics,
@@ -195,7 +221,8 @@ had no harness.
 | **#1913 enemy follow-freeze** | "niamu blessed a stand-beside-attack design; CalebJohn: 'shouldn't be too hard' — **best next code win.**" | Issue #1913 is **open with ZERO comments** (author CalebJohn: "not really sure what this would look like"). No blessing, no such quote exists in it. | **Downgrade.** Not a blessed quick win. |
 | **PR #2229** (the real attempt at #1913/#2036) | (not clearly flagged) | **niamu CLOSED it (May 2015) as "too big of a core gameplay change… a level design issue instead."** 8bitgentleman & niamu openly disagreed on approach in-thread. | The one time this was tried, the lead maintainer backed it out. **Needs a fresh design decision from the owner before any revival — do not just re-implement.** |
 | **#2491 `caveblocks`** | Ship level+HP changes, drop the manual black outlines (niamu's SVG objection). | ✅ **Accurate.** niamu supports lower forest-block HP; niamu + edisonout object to hand-painted outlines (keep art "pure" for future SVG/programmatic borders); 8bitgentleman conceded but "the tileset and level changes are solid." | Ship level + HP-to-1 only; rework/drop outlines. **Genuinely the cleanest quick win now.** |
-| **#2584 / #2427 / #2578** | #2427 "likely already fixed"; #2578 "partially fixed, bat path unverified." | ✅ **Confirmed & now improved:** fix is merged + intact; author explicitly couldn't test the bat path; niamu accepted on code-reasoning only. Now covered by new unit tests. | Live-verify + close (see §3). |
+| **#2584 / #2456 / #2578** | #2578 "partially fixed, bat path unverified." | ✅ **Fixed + now verified end-to-end.** Merged fix intact; unit tests + scenario tests (PR #48) drive the real Level/Player loop, including the bat-knockback ceiling case the author couldn't test. | Re-confirm done; close #2456/#2578. |
+| **#2427** | "likely already fixed." | ❌ **WRONG — open & unfixed.** #2584 closed #2456/#2578, not #2427. Timing/geometry-dependent moving-platform fall-through; no closing commit, no maintainer verdict. | **Do NOT close.** Needs harness work + a real fix (see §3). |
 
 ---
 
@@ -315,8 +342,9 @@ legitimately lift old constraints — but deliberately, not by accident.*
    deleted once you've confirmed `develop` has everything.
 2. **#2491 `caveblocks`** — revive the level + HP-to-1 changes only, rework/drop the outline
    edits. ✅ genuinely blessed; cleanest quick win.
-3. **Live-verify + close #2427** (and re-confirm #2578) on `black-caverns-2` / Forest now that
-   maps compile.
+3. ✅ **#2578 / #2456 verified end-to-end** (PR #48) — done. **#2427 is open & unfixed** (not a
+   close): it needs a dedicated harness task (reliable land-player-on-platform + moving-platform
+   teardown) then a real fix. See §3 for the parked investigation + repro obstacles.
 4. **#2442 New HUD** — static-icon + spacing fixes (📎 re-read the thread first).
 5. **The fork in the road (owner's creative call):** either content ("feel like the show" — Gay
    Island integration, Hilda questline + quest-module refactor, revive Paintball) and/or **local

--- a/src/test/test_collision_ceiling_scenario.lua
+++ b/src/test/test_collision_ceiling_scenario.lua
@@ -1,0 +1,136 @@
+-- End-to-end (gameplay-level) regression tests for the ceiling-collision family
+-- fixed by merged PR #2584 ("Addresses two common collision issues"):
+--   #2456 - attack/stand after a crouch under a low ceiling clips the player up
+--   #2578 - a bat knockback (or standing at a ceiling edge) warps the player up
+--           through a ceiling tile
+--
+-- test_collision_ceiling.lua already pins the underlying collision math in
+-- isolation. These tests are the companion the PR author explicitly could NOT
+-- write at the time -- on the #2578 thread: "I'm not sure how to have a
+-- repeatable test with being hit by a bat to knock you into the ceiling."
+--
+-- They drive the *real* Level + Player update loop through the headless
+-- scenario harness: real map geometry, real Player:updatePosition ->
+-- collision.move, real crouch-aware bounding box. A solid ceiling tile is added
+-- to a plain side-scrolling level's collision layer, then the exact in-game bat
+-- knockback impulse (Enemy:collide sets player.velocity.y = -450, enemy.lua) is
+-- applied and the physics stepped at a fixed dt.
+
+local Scenario = require 'test/scenario'
+
+-- greendale-biology is a plain side-scroller with a `collision` tilelayer and no
+-- moving platforms, so the harness can drive it deterministically. The player
+-- spawns over open ground; the tiles directly above the spawn column are empty,
+-- which is where we drop a synthetic ceiling.
+local FIXTURE = 'greendale-biology'
+
+-- Return the map's `collision` tilelayer (the one collision.lua reads).
+local function collision_layer(map)
+  for _, layer in ipairs(map.tilelayers) do
+    if layer.name == 'collision' then return layer end
+  end
+  error('fixture ' .. FIXTURE .. ' has no collision tilelayer')
+end
+
+-- Drop a solid block tile (id 0) into the cell containing world (x, y).
+-- Returns the tile's top and bottom (underside) world-y edges.
+local function put_ceiling(map, x, y)
+  local layer = collision_layer(map)
+  local col = math.floor(x / map.tilewidth) + 1
+  local row = math.floor(y / map.tileheight)
+  layer.tiles[row * map.width + col] = { id = 0 }
+  return row * map.tileheight, (row + 1) * map.tileheight
+end
+
+-- Boot the fixture and let gravity settle the player onto the floor.
+local function settled_scenario()
+  local s = Scenario.new(FIXTURE)
+  s:step(30)
+  return s
+end
+
+-- #2578, the actual bat scenario: a knockback impulse launches the player up
+-- into a low ceiling. The player must be stopped cleanly at the ceiling's
+-- underside and never pass through it, then fall back to the floor -- not clip
+-- up and stick on top of the geometry.
+function test_bat_knockback_stops_at_ceiling_and_returns()
+  local s = settled_scenario()
+  local p = s.player
+  local floorY = p.position.y
+  local cx = p.position.x + p.character.bbox.width / 2
+
+  -- Ceiling with its underside ~19px above the player's head (box top).
+  local ceilTop, ceilUnder = put_ceiling(s.level.map, cx, floorY - 34)
+
+  -- The exact impulse Enemy:collide applies to the player on a hit.
+  p.velocity.y = -450
+
+  local minY = p.position.y
+  for _ = 1, 120 do
+    s:step(1)
+    minY = math.min(minY, p.position.y)
+  end
+
+  -- The player's box top never rises above the ceiling tile's top edge
+  -- (a clip-through would leave them sitting on top of it, box top < ceilTop).
+  assert_true(minY >= ceilTop,
+    string.format("knockback clipped through ceiling: minY=%.1f < ceilTop=%.1f",
+                  minY, ceilTop))
+  -- Sanity: they actually reached the ceiling (the impulse was strong enough).
+  assert_true(minY <= ceilUnder + 1,
+    "player did not reach the ceiling; impulse/geometry is wrong for this test")
+  -- And gravity brings them back down to the floor.
+  assert_true(math.abs(p.position.y - floorY) < 1,
+    string.format("player did not settle back on the floor: y=%.1f floor=%.1f",
+                  p.position.y, floorY))
+
+  s:teardown()
+end
+
+-- #2578, the down-branch guard specifically (collision.move_y's `slope_y >= new_y`).
+-- Reproduces the "standing at a ceiling edge" state end-to-end: the player's box
+-- top sits inside a ceiling tile's vertical span and gravity applies a small
+-- downward tick. Pre-#2584 the downward scan found that tile *above* the new
+-- position and returned `slope_y - height`, warping the player up onto the
+-- ceiling. With the guard, they simply continue to fall.
+--
+-- Removing the `slope_y >= new_y` guard in collision.move_y makes this fail
+-- (the player warps from a box top of ~246 up to ~199) -- so it pins the fix.
+function test_ceiling_edge_downtick_does_not_warp_up()
+  local s = settled_scenario()
+  local p = s.player
+  local cx = p.position.x + p.character.bbox.width / 2
+
+  -- A ceiling tile straddling the player's head, then embed the box top inside
+  -- the tile's vertical span -- the exact ceiling-edge state the bug needs.
+  local ceilTop, ceilUnder = put_ceiling(s.level.map, cx, p.position.y - 10)
+  p.position.y = ceilTop + 6
+  p:moveBoundingBox()
+  p.velocity.y = 20 -- a gentle, gravity-like downward tick
+
+  local before = p.position.y
+  s:step(1)
+
+  assert_true(p.position.y >= before,
+    string.format("player warped UP through the ceiling: %.1f -> %.1f (tile %.0f..%.0f)",
+                  before, p.position.y, ceilTop, ceilUnder))
+  s:teardown()
+end
+
+-- #2456: crouched under a ceiling too low to stand under, the player must not be
+-- able to reclaim full height (which pre-#2584 clipped them up into the ceiling).
+-- Player:canStand -> collision.stand gates standing up; it must report false.
+function test_cannot_stand_up_into_low_ceiling()
+  local s = settled_scenario()
+  local p = s.player
+  local cx = p.position.x + p.character.bbox.width / 2
+  local grow = p.character.bbox.height - p.character.bbox.duck_height
+
+  -- Ceiling low enough that a full-height hitbox would intersect it but a ducked
+  -- one fits: underside just inside the standing box's headroom.
+  put_ceiling(s.level.map, cx, p.position.y - grow + 4)
+
+  assert_false(p:canStand(s.level.map),
+    "player must not be able to stand up into a solid ceiling tile")
+  s:teardown()
+end


### PR DESCRIPTION
## What

Three end-to-end (gameplay-level) regression tests in `src/test/test_collision_ceiling_scenario.lua`, covering the ceiling-collision family fixed by merged PR #2584:

- `test_bat_knockback_stops_at_ceiling_and_returns` — the actual bat scenario (#2578): the in-game knockback impulse (`player.velocity.y = -450`, from `Enemy:collide`) launches the player into a low ceiling; they stop cleanly at the underside, never clip through, and fall back to the floor.
- `test_ceiling_edge_downtick_does_not_warp_up` — #2578's specific fix: the "standing at a ceiling edge" state + a gravity down-tick. Pins the `collision.move_y` `slope_y >= new_y` guard.
- `test_cannot_stand_up_into_low_ceiling` — #2456: crouched under a low ceiling, `Player:canStand` must report false.

A second commit corrects `HAWKTHORNE_HANDOFF_v2.md`: the handoff wrongly listed **#2427** as "likely already fixed, close as resolved." PR #2584 closed #2456/#2578, **not** #2427 — that issue is still open (moving-platform fall-through), with no closing commit or maintainer verdict. The doc now records the end-to-end verification here and parks the #2427 investigation for a dedicated harness task.

## Why

`test_collision_ceiling.lua` already pins the collision *math* in isolation. These drive the **real** `Level` + `Player` update loop through the headless scenario harness (real map geometry, real `Player:updatePosition` → `collision.move`, real crouch-aware hitbox) — the companion the PR #2584 author explicitly couldn't write ("I'm not sure how to have a repeatable test with being hit by a bat to knock you into the ceiling").

## Verification

- Full suite: **98 passed, 0 failed** (was 95; +3).
- Genuine regression guard: reverting the `slope_y >= new_y` guard in `collision.move_y` fails `test_ceiling_edge_downtick_does_not_warp_up` (`player warped UP through the ceiling: 246.0 → 199.0`) alongside the existing unit test; restore it and all green.
- Test file lint-clean.
